### PR TITLE
Periodic WattTime weekly data refresh

### DIFF
--- a/server/consts_p.go
+++ b/server/consts_p.go
@@ -18,5 +18,6 @@ const (
 	testMode                = false
 	wattTimeFrequency       = 2 * time.Minute
 
-	ReportMigrationFrequency = 1 * time.Hour
+	ReportMigrationFrequency        = 1 * time.Hour
+	WattTimeWeekDataUpdateFrequency = 24 * time.Hour
 )

--- a/server/consts_t.go
+++ b/server/consts_t.go
@@ -18,5 +18,6 @@ const (
 	testMode                = true
 	wattTimeFrequency       = 20 * time.Millisecond
 
-	ReportMigrationFrequency = 100 * time.Millisecond
+	ReportMigrationFrequency        = 100 * time.Millisecond
+	WattTimeWeekDataUpdateFrequency = 1000 * time.Millisecond
 )

--- a/server/server.go
+++ b/server/server.go
@@ -203,6 +203,7 @@ func NewGCAServer(baseDir string) (*GCAServer, error) {
 	go server.threadedMigrateReports(username, password, migrateReady)
 	go server.threadedListenForSyncRequests(tcpReady)
 	go server.threadedCollectImpactData(username, password)
+	go server.threadedGetWattTimeWeekData(username, password)
 	server.launchAPI()
 
 	<-udpReady

--- a/server/watttime.go
+++ b/server/watttime.go
@@ -308,6 +308,11 @@ func (gcas *GCAServer) managedGetWattTimeIndexData(username, password string) er
 // managedGetWattTimeWeekData will grab all of the data for the latest week and
 // fill out the impact rates as much as possible.
 func (gcas *GCAServer) managedGetWattTimeWeekData(username, password string) error {
+	// Disable this test during testing, as the testing does not have WattTime access.
+	if testMode {
+		return nil
+	}
+
 	// Get a new auth token. They expire relatively quickly so it's better
 	// to get a new token every time this function is called.
 	token, err := staticGetWattTimeToken(username, password)
@@ -426,6 +431,8 @@ func (gcas *GCAServer) threadedGetWattTimeWeekData(username, password string) {
 		case <-time.After(WattTimeWeekDataUpdateFrequency):
 		}
 
+		// This API is called during startup, so it is safe to sleep before calling it here. The
+		// intention is to call it periodically, most likely once per day.
 		err := gcas.managedGetWattTimeWeekData(username, password)
 		if err != nil {
 			gcas.logger.Errorf("Threaded call unable to get WattTime data for the most recent week: %v", err)

--- a/server/watttime.go
+++ b/server/watttime.go
@@ -308,7 +308,7 @@ func (gcas *GCAServer) managedGetWattTimeIndexData(username, password string) er
 // managedGetWattTimeWeekData will grab all of the data for the latest week and
 // fill out the impact rates as much as possible.
 func (gcas *GCAServer) managedGetWattTimeWeekData(username, password string) error {
-	// Disable this test during testing, as the testing does not have WattTime access.
+	// Disable this during testing, as the testing does not have WattTime access.
 	if testMode {
 		return nil
 	}


### PR DESCRIPTION
As a defensive measure for 0 data condition, run the data refresh daily. Improve the logging to narrow down the problem if it is seen again.