### PR TITLE
update equipment-setup.sh

### DIFF
--- a/bin/gca-admin/equipment-setup.sh
+++ b/bin/gca-admin/equipment-setup.sh
@@ -7,10 +7,22 @@ ssh-copy-id halki@$2
 sleep 4
 scp .config/gca-data/clients/client_$1/* halki@$2:/home/halki/
 sleep 4
+ssh halki@$2 'sudo systemctl stop glow_monitor.service'
+sleep 1
+ssh halki@$2 'sudo systemctl stop atm90e32.service'
+sleep 1
 scp .config/gca-data/clients/glow-monitor halki@$2:/home/halki
+sleep 4
+scp .config/gca-data/clients/halki-app halki@$2:/home/halki
 sleep 4
 
 ssh halki@$2 'sudo mv /home/halki/glow-monitor /usr/bin/glow-monitor'
 sleep 4
+ssh halki@$2 'sudo mv /home/halki/halki-app /usr/bin/halki-app'
+sleep 4
 ssh halki@$2 'sudo mv /home/halki/* /opt/glow-monitor/'
 sleep 4
+ssh halki@$2 'sudo systemctl start glow_monitor.service'
+sleep 1
+ssh halki@$2 'sudo systemctl start atm90e32.service'
+sleep 1


### PR DESCRIPTION
The new firmware requires uploading a new version of glow-monitor and also a new version of the halki-app binary, and resetting both of the corresponding services.

This PR modifies equipment-setup.sh on the gca lockbook so that the firmware updates get applied.