### PR TITLE
concurrency test intermittant failure

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -29,6 +29,7 @@ func (gcas *GCAServer) launchAPI() {
 
 	// Launch the background thread that keeps the API running.
 	go func() {
+		defer gcas.httpWg.Done()
 		gcas.logger.Info("Starting HTTP server on port ", gcas.httpPort)
 		if err := gcas.httpServer.Serve(listener); err != nil && err != http.ErrServerClosed {
 			gcas.logger.Fatal("Could not start HTTP server: ", err)

--- a/server/api.go
+++ b/server/api.go
@@ -29,7 +29,6 @@ func (gcas *GCAServer) launchAPI() {
 
 	// Launch the background thread that keeps the API running.
 	go func() {
-		defer gcas.httpWg.Done()
 		gcas.logger.Info("Starting HTTP server on port ", gcas.httpPort)
 		if err := gcas.httpServer.Serve(listener); err != nil && err != http.ErrServerClosed {
 			gcas.logger.Fatal("Could not start HTTP server: ", err)

--- a/server/consts_p.go
+++ b/server/consts_p.go
@@ -17,6 +17,7 @@ const (
 	defaultLogLevel         = WARN
 	testMode                = false
 	wattTimeFrequency       = 2 * time.Minute
+	httpServerCtxTimeout    = 5 * time.Second
 
 	ReportMigrationFrequency        = 1 * time.Hour
 	WattTimeWeekDataUpdateFrequency = 24 * time.Hour

--- a/server/consts_t.go
+++ b/server/consts_t.go
@@ -17,7 +17,7 @@ const (
 	defaultLogLevel         = DEBUG
 	testMode                = true
 	wattTimeFrequency       = 20 * time.Millisecond
-	httpServerCtxTimeout    = 20 * time.Second // server concurrency test fails intermittantly with 5 second value
+	httpServerCtxTimeout    = 5 * time.Second
 
 	ReportMigrationFrequency        = 100 * time.Millisecond
 	WattTimeWeekDataUpdateFrequency = 1000 * time.Millisecond

--- a/server/consts_t.go
+++ b/server/consts_t.go
@@ -17,7 +17,7 @@ const (
 	defaultLogLevel         = DEBUG
 	testMode                = true
 	wattTimeFrequency       = 20 * time.Millisecond
-	httpServerCtxTimeout    = 5 * time.Second
+	httpServerCtxTimeout    = 1 * time.Second
 
 	ReportMigrationFrequency        = 100 * time.Millisecond
 	WattTimeWeekDataUpdateFrequency = 1000 * time.Millisecond

--- a/server/consts_t.go
+++ b/server/consts_t.go
@@ -17,6 +17,7 @@ const (
 	defaultLogLevel         = DEBUG
 	testMode                = true
 	wattTimeFrequency       = 20 * time.Millisecond
+	httpServerCtxTimeout    = 20 * time.Second // server concurrency test fails intermittantly with 5 second value
 
 	ReportMigrationFrequency        = 100 * time.Millisecond
 	WattTimeWeekDataUpdateFrequency = 1000 * time.Millisecond

--- a/server/equipment.go
+++ b/server/equipment.go
@@ -247,6 +247,7 @@ func (gcas *GCAServer) saveEquipment(ea glow.EquipmentAuthorization) (bool, erro
 // totally ready to go, so the 'ready' channel is used to signal to startup
 // that it's okay to proceed.
 func (gcas *GCAServer) threadedMigrateReports(username, password string, ready chan struct{}) {
+	defer gcas.shutWg.Done()
 	readyClosed := false
 	for {
 		gcas.mu.Lock()
@@ -262,6 +263,7 @@ func (gcas *GCAServer) threadedMigrateReports(username, password string, ready c
 			// fine, even though action is only taken once a week.
 			select {
 			case <-gcas.quit:
+				gcas.logger.Info("migrate reports quit signal recieved")
 				return
 			case <-time.After(ReportMigrationFrequency):
 			}

--- a/server/server.go
+++ b/server/server.go
@@ -5,6 +5,7 @@ package server
 // them all down as well.
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io/ioutil"
@@ -12,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime/pprof"
 	"sync"
 
 	"github.com/glowlabs-org/gca-backend/glow"
@@ -234,6 +236,14 @@ func (server *GCAServer) Close() error {
 	if err != nil {
 		// Log the error if the shutdown fails.
 		server.logger.Errorf("HTTP server shutdown error: %v", err)
+
+		// Log additional information about this error
+		var buf bytes.Buffer
+		if p := pprof.Lookup("goroutine"); p != nil {
+			p.WriteTo(&buf, 1) // The second argument is debug level
+		}
+		fmt.Printf("http shutdown debug: %v", buf.String())
+
 		return fmt.Errorf("error shutting down the http server: %v", err)
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -5,7 +5,6 @@ package server
 // them all down as well.
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io/ioutil"
@@ -13,7 +12,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"runtime/pprof"
 	"sync"
 
 	"github.com/glowlabs-org/gca-backend/glow"
@@ -248,16 +246,6 @@ func (server *GCAServer) Close() error {
 	if err != nil {
 		// Log the error if the shutdown fails.
 		server.logger.Errorf("HTTP server shutdown error: %v", err)
-
-		if testMode {
-			// Log additional information about this error
-			var buf bytes.Buffer
-			if p := pprof.Lookup("goroutine"); p != nil {
-				p.WriteTo(&buf, 1) // The second argument is debug level
-			}
-			server.logger.Info("http shutdown debug", buf.String())
-		}
-
 		return fmt.Errorf("error shutting down the http server: %v", err)
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -99,7 +99,6 @@ type GCAServer struct {
 	tcpPort        uint16         // The port that the TCP listener is using
 	quit           chan bool      // A channel to initiate server shutdown
 	shutWg         sync.WaitGroup // Waiter for server threads shutdown
-	httpWg         sync.WaitGroup // Waiter for http server shutdown
 	mu             sync.Mutex
 }
 
@@ -208,7 +207,6 @@ func NewGCAServer(baseDir string) (*GCAServer, error) {
 	go server.threadedListenForSyncRequests(tcpReady)
 	go server.threadedCollectImpactData(username, password)
 	go server.threadedGetWattTimeWeekData(username, password)
-	server.httpWg.Add(1)
 	server.launchAPI()
 
 	<-udpReady

--- a/server/server.go
+++ b/server/server.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"time"
 
 	"github.com/glowlabs-org/gca-backend/glow"
 )
@@ -227,7 +226,7 @@ func (server *GCAServer) Close() error {
 	close(server.quit)
 
 	// Shutdown the HTTP server gracefully
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), httpServerCtxTimeout)
 	defer cancel()
 
 	// Initiate the shutdown.

--- a/server/sync_listener_tcp.go
+++ b/server/sync_listener_tcp.go
@@ -32,34 +32,56 @@ import (
 // queries that want to see which timeslots have reports for a given piece of
 // hardware.
 func (gcas *GCAServer) threadedListenForSyncRequests(tcpReady chan struct{}) {
+	defer gcas.shutWg.Done()
 	// Listen on TCP port
 	listener, err := net.Listen("tcp", tcpPort)
 	if err != nil {
 		gcas.logger.Fatalf("Failed to start server: %s", err)
 	}
 	gcas.tcpListener = listener
-	defer listener.Close()
 	gcas.tcpPort = uint16(listener.Addr().(*net.TCPAddr).Port)
 	close(tcpReady)
+
+	// To manage connections without blocking, use a separate go routine
+	connCh := make(chan net.Conn)
+	doneCh := make(chan bool)
+	go func() {
+		for {
+			// Wait for a connection
+			conn, err := listener.Accept()
+
+			// Check for server quit
+			select {
+			case <-gcas.quit:
+				doneCh <- true
+				return
+			default:
+				// Accepted connection
+			}
+
+			if err != nil {
+				gcas.logger.Infof("Failed to accept connection: %s", err)
+				continue
+			}
+			connCh <- conn
+		}
+	}()
 
 	for {
 		// Check for a shutdown signal.
 		select {
 		case <-gcas.quit:
+			gcas.logger.Info("tcp server quit signal recieved")
+
+			// close the listener here, and wait for the accept thread to exit
+			listener.Close()
+			<-doneCh
+
 			return
-		default:
-			// Wait for the next incoming request
+		case conn := <-connCh:
+			// Handle the connection in a new goroutine
+			go gcas.managedHandleSyncConn(conn)
 		}
-
-		// Wait for a connection
-		conn, err := listener.Accept()
-		if err != nil {
-			gcas.logger.Infof("Failed to accept connection: %s", err)
-			continue
-		}
-
-		// Handle the connection in a new goroutine
-		go gcas.managedHandleSyncConn(conn)
 	}
 }
 

--- a/server/sync_listener_tcp.go
+++ b/server/sync_listener_tcp.go
@@ -56,7 +56,6 @@ func (gcas *GCAServer) threadedListenForSyncRequests(tcpReady chan struct{}) {
 				doneCh <- true
 				return
 			default:
-				// Accepted connection
 			}
 
 			if err != nil {

--- a/server/watttime.go
+++ b/server/watttime.go
@@ -222,6 +222,7 @@ func getWattTimeData(token string, latitude float64, longitude float64, startTim
 // WattTime period is 5 minutes, so we'll be grabbing the same datapoint pretty
 // regularly.
 func (gcas *GCAServer) threadedCollectImpactData(username, password string) {
+	defer gcas.shutWg.Done()
 	// Infinite loop to keep fetching data from WattTime.
 	for {
 		// Soft sleep before collecting data. We sleep before instead
@@ -229,6 +230,7 @@ func (gcas *GCAServer) threadedCollectImpactData(username, password string) {
 		// iteration of the loop and the sleep will happen.
 		select {
 		case <-gcas.quit:
+			gcas.logger.Info("collect impact data quit signal recieved")
 			return
 		case <-time.After(wattTimeFrequency):
 		}
@@ -424,9 +426,11 @@ func staticGetWattTimeToken(username, password string) (string, error) {
 // threadedGetWattTimeWeekData wakes up periodically and refreshes the weekly
 // WattTime data.
 func (gcas *GCAServer) threadedGetWattTimeWeekData(username, password string) {
+	defer gcas.shutWg.Done()
 	for {
 		select {
 		case <-gcas.quit:
+			gcas.logger.Info("weekly data quit signal recieved")
 			return
 		case <-time.After(WattTimeWeekDataUpdateFrequency):
 		}


### PR DESCRIPTION
The concurrency test fails intermittantly, on a timeout during http server shutdown. Tracking with https://github.com/glowlabs-org/gca-backend/issues/7

The strategy to work on this problem will be to ensure that all networking thread shutdowns complete, then work on improving the http server shutdown behavior.

The concurrency test finishes under 1 sec most the time on desktop, but occasionally it is over 5 seconds, causing the test to fail during http server shutdown.

go test -v -tags test -count 10   ./server/... -run TestConcurrency
...
=== RUN   TestConcurrency
    server_concurrency_test.go:351: equipment 9 hit rate: 1 :: 241 :: 44 :: 204
    server_concurrency_test.go:351: equipment 5 hit rate: 1 :: 241 :: 44 :: 208
    server_concurrency_test.go:351: equipment 1 hit rate: 0.6239669421487604 :: 242 :: 151 :: 0
--- PASS: TestConcurrency (0.59s)
=== RUN   TestConcurrency
    server_concurrency_test.go:351: equipment 9 hit rate: 1 :: 186 :: 28 :: 162
    server_concurrency_test.go:351: equipment 1 hit rate: 0.675531914893617 :: 188 :: 126 :: 0
    server_concurrency_test.go:351: equipment 5 hit rate: 0.9946808510638298 :: 188 :: 31 :: 167
--- PASS: TestConcurrency (6.40s)
=== RUN   TestConcurrency
    server_concurrency_test.go:351: equipment 1 hit rate: 0.6625766871165644 :: 163 :: 108 :: 0
    server_concurrency_test.go:351: equipment 6 hit rate: 1 :: 163 :: 26 :: 139
    server_concurrency_test.go:351: equipment 5 hit rate: 1 :: 163 :: 26 :: 137
--- PASS: TestConcurrency (0.57s)
=== RUN   TestConcurrency
