### PR TITLE
Managed shutdown

### DIFF
--- a/client/reports.go
+++ b/client/reports.go
@@ -532,6 +532,7 @@ func (c *Client) threadedSyncWithServer(latestReading uint32) bool {
 // The thread needs to complete some initialization tasks before the client is
 // completely ready, that gets coordinated with a basic channel.
 func (c *Client) threadedSendReports(ready chan struct{}) {
+	defer c.closedWg.Done()
 	// Right at startup, we save all of the existing records. We don't
 	// bother sending them because we assume we already sent them, and if
 	// we haven't already sent them, the periodic synchronization will fix

--- a/server/equipment.go
+++ b/server/equipment.go
@@ -247,6 +247,7 @@ func (gcas *GCAServer) saveEquipment(ea glow.EquipmentAuthorization) (bool, erro
 // totally ready to go, so the 'ready' channel is used to signal to startup
 // that it's okay to proceed.
 func (gcas *GCAServer) threadedMigrateReports(username, password string, ready chan struct{}) {
+	defer gcas.shutWg.Done()
 	readyClosed := false
 	for {
 		gcas.mu.Lock()
@@ -262,6 +263,7 @@ func (gcas *GCAServer) threadedMigrateReports(username, password string, ready c
 			// fine, even though action is only taken once a week.
 			select {
 			case <-gcas.quit:
+				gcas.logger.Info("migrate reports quit signal recieved")
 				return
 			case <-time.After(ReportMigrationFrequency):
 			}

--- a/server/report_listener_udp.go
+++ b/server/report_listener_udp.go
@@ -172,7 +172,6 @@ func (server *GCAServer) threadedLaunchUDPServer(udpReady chan struct{}) {
 		panic("bad type on udpConn")
 	}
 	server.udpPort = uint16(addr.Port)
-	close(udpReady)
 	if err != nil {
 		server.logger.Fatal("UDP server launch failed: ", err)
 	}
@@ -207,6 +206,8 @@ func (server *GCAServer) threadedLaunchUDPServer(udpReady chan struct{}) {
 			dataCh <- buffer
 		}
 	}()
+
+	close(udpReady)
 
 	// Continuously listen for incoming UDP packets
 	for {

--- a/server/server.go
+++ b/server/server.go
@@ -98,6 +98,7 @@ type GCAServer struct {
 	udpPort        uint16         // The port that the UDP conn is listening on
 	tcpPort        uint16         // The port that the TCP listener is using
 	quit           chan bool      // A channel to initiate server shutdown
+	shutWg         sync.WaitGroup // Waiter for server shutdown
 	mu             sync.Mutex
 }
 
@@ -200,6 +201,7 @@ func NewGCAServer(baseDir string) (*GCAServer, error) {
 	}
 
 	// Start the background threads for various server functionalities
+	server.shutWg.Add(5)
 	go server.threadedLaunchUDPServer(udpReady)
 	go server.threadedMigrateReports(username, password, migrateReady)
 	go server.threadedListenForSyncRequests(tcpReady)
@@ -224,8 +226,11 @@ func (server *GCAServer) Close() error {
 		server.CheckInvariants()
 	}
 
-	// Signal to terminate the server
+	// Signal to terminate the server threads, and wait for them to exit
+	server.logger.Info("server quit signalled")
 	close(server.quit)
+	server.shutWg.Wait()
+	server.logger.Info("server quit wait completed")
 
 	// Shutdown the HTTP server gracefully
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -237,23 +242,6 @@ func (server *GCAServer) Close() error {
 		// Log the error if the shutdown fails.
 		server.logger.Errorf("HTTP server shutdown error: %v", err)
 		return fmt.Errorf("error shutting down the http server: %v", err)
-	}
-
-	// Close the TCP and UDP connection
-	server.mu.Lock()
-	var err1, err2 error
-	if server.udpConn != nil {
-		err1 = server.udpConn.Close()
-	}
-	if server.tcpListener != nil {
-		err2 = server.tcpListener.Close()
-	}
-	server.mu.Unlock()
-	if err1 != nil {
-		return fmt.Errorf("error closing the udp connection: %v", err1)
-	}
-	if err2 != nil {
-		return fmt.Errorf("error closing the tcp connection: %v", err2)
 	}
 
 	// Close the logger

--- a/server/server.go
+++ b/server/server.go
@@ -233,7 +233,7 @@ func (server *GCAServer) Close() error {
 	server.logger.Info("server quit wait completed")
 
 	// Shutdown the HTTP server gracefully
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	// Initiate the shutdown.

--- a/server/sync_listener_tcp.go
+++ b/server/sync_listener_tcp.go
@@ -41,7 +41,6 @@ func (gcas *GCAServer) threadedListenForSyncRequests(tcpReady chan struct{}) {
 	}
 	gcas.tcpListener = listener
 	gcas.tcpPort = uint16(listener.Addr().(*net.TCPAddr).Port)
-	close(tcpReady)
 
 	// To manage connections without blocking, use a separate go routine
 	connCh := make(chan net.Conn)
@@ -67,6 +66,8 @@ func (gcas *GCAServer) threadedListenForSyncRequests(tcpReady chan struct{}) {
 			connCh <- conn
 		}
 	}()
+
+	close(tcpReady)
 
 	for {
 		// Check for a shutdown signal.

--- a/server/watttime.go
+++ b/server/watttime.go
@@ -222,6 +222,7 @@ func getWattTimeData(token string, latitude float64, longitude float64, startTim
 // WattTime period is 5 minutes, so we'll be grabbing the same datapoint pretty
 // regularly.
 func (gcas *GCAServer) threadedCollectImpactData(username, password string) {
+	defer gcas.shutWg.Done()
 	// Infinite loop to keep fetching data from WattTime.
 	for {
 		// Soft sleep before collecting data. We sleep before instead
@@ -229,6 +230,7 @@ func (gcas *GCAServer) threadedCollectImpactData(username, password string) {
 		// iteration of the loop and the sleep will happen.
 		select {
 		case <-gcas.quit:
+			gcas.logger.Info("collect impact data quit signal recieved")
 			return
 		case <-time.After(wattTimeFrequency):
 		}
@@ -424,9 +426,11 @@ func staticGetWattTimeToken(username, password string) (string, error) {
 // threadedGetWattTimeWeekData wakes up periodically and refreshes the weekly
 // WattTime data.
 func (gcas *GCAServer) threadedGetWattTimeWeekData(username, password string) {
+	defer gcas.shutWg.Done()
 	for {
 		select {
 		case <-gcas.quit:
+			gcas.logger.Info("weekly data quit signal recieved")
 			return
 		case <-time.After(WattTimeWeekDataUpdateFrequency):
 		}


### PR DESCRIPTION
Managed shutdown for client and server using wait groups. Ensure that the udp and tcp server threads do not block in the main thread.