### PR TITLE
ct settings file

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -51,7 +51,6 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -156,7 +155,7 @@ func (c *Client) Close() error {
 // this case anyway.
 func (c *Client) loadKeypair() error {
 	path := filepath.Join(c.staticBaseDir, ClientKeyFile)
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
 		return fmt.Errorf("client keys not found, the client was configured incorrectly")
 	}
@@ -173,7 +172,7 @@ func (c *Client) loadKeypair() error {
 // to the GCA.
 func (c *Client) loadGCAPub() error {
 	path := filepath.Join(c.staticBaseDir, GCAPubKeyFile)
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
 		return fmt.Errorf("client keys not found, the client was configured incorrectly")
 	}
@@ -189,7 +188,7 @@ func (c *Client) loadGCAPub() error {
 // themselves, so the client only needs to send to one of them.
 func (c *Client) loadGCAServers() error {
 	path := filepath.Join(c.staticBaseDir, GCAServerMapFile)
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
 		return fmt.Errorf("GCA server file not found, client was configured incorrectly: %v", err)
 	}
@@ -209,7 +208,7 @@ func (c *Client) loadGCAServers() error {
 	// non-banned server from the randomized list. This ensures that even
 	// at startup the client is being robust against bad actors.
 	servers := make([]glow.PublicKey, 0, len(c.gcaServers))
-	for server, _ := range c.gcaServers {
+	for server := range c.gcaServers {
 		servers = append(servers, server)
 	}
 	for i := range servers {
@@ -235,7 +234,7 @@ func (c *Client) loadGCAServers() error {
 // 5 minutes for 10 years.
 func (c *Client) loadShortID() error {
 	path := filepath.Join(c.staticBaseDir, ShortIDFile)
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
 		return fmt.Errorf("client shortID not found, the client was configured incorrectly")
 	}

--- a/client/consts.go
+++ b/client/consts.go
@@ -22,4 +22,7 @@ const (
 	// ShortIDFile contains the ShortID of the device, which is useful for
 	// compressing communications with the GCA servers.
 	ShortIDFile = "shortID.dat"
+
+	// CTSettingsFile contains the current transformer multiplier.
+	CTSettingsFile = "ct-settings.txt"
 )

--- a/client/consts_p.go
+++ b/client/consts_p.go
@@ -25,8 +25,10 @@ const (
 
 	// CTMultiplier is the multiplier that we use on the current
 	// transformer to correctly normalize the readings from the current
-	// transformer.
-	EnergyMultiplier = -2000
+	// transformer. The reported energy value is first multiplied, then divided by
+	// these values.
+	EnergyMultiplierDefault = -2000
+	EnergyDividerDefault    = 1000
 
 	// UDPSleepSyncTime sets the amount of time that the system sleeps
 	// between each UDP packet that gets sent. We sleep between packets

--- a/client/consts_t.go
+++ b/client/consts_t.go
@@ -21,8 +21,10 @@ const (
 
 	// CTMultiplier is the multiplier that we use on the current
 	// transformer to correctly normalize the readings from the current
-	// transformer.
-	EnergyMultiplier = 1000
+	// transformer. The reported energy value is first multiplied, then divided by
+	// these values.
+	EnergyMultiplierDefault = 1000
+	EnergyDividerDefault    = 1000
 
 	// UDPSleepSyncTime sets the amount of time that the system sleeps
 	// between each UDP packet that gets sent. We sleep between packets

--- a/client/ct_settings_test.go
+++ b/client/ct_settings_test.go
@@ -81,3 +81,67 @@ func TestCISettings(t *testing.T) {
 		}
 	}
 }
+
+func TestCISettingsMalformed(t *testing.T) {
+	name := t.Name()
+	gcas, _, gcaPubkey, gcaPrivKey, err := server.SetupTestEnvironment(name + "_server1")
+	if err != nil {
+		t.Errorf("unable to set up the test environment for a server: %v", err)
+	}
+	defer gcas.Close()
+	clientDir := glow.GenerateTestDir(name + "_client1")
+	err = SetupTestEnvironment(clientDir, gcaPubkey, gcaPrivKey, []*server.GCAServer{gcas})
+	if err != nil {
+		t.Errorf("unable to set up the client test environment: %v", err)
+	}
+	// create a malformed ct settings file
+	ctPath := path.Join(clientDir, CTSettingsFile)
+	ctf, err := os.Create(ctPath)
+	if err != nil {
+		t.Errorf("could not open ct settings file: %v", err)
+	}
+	ctContent := "-2000\nwhoops\n"
+	_, err = ctf.WriteString(ctContent)
+	if err != nil {
+		ctf.Close()
+		t.Errorf("unable to write ct settings file: %v", err)
+	}
+	// try to start the client
+	client, err := NewClient(clientDir)
+	if err == nil {
+		client.Close()
+		t.Errorf("client read the malformed ct settings file")
+	}
+}
+
+func TestCISettingsMissingValue(t *testing.T) {
+	name := t.Name()
+	gcas, _, gcaPubkey, gcaPrivKey, err := server.SetupTestEnvironment(name + "_server1")
+	if err != nil {
+		t.Errorf("unable to set up the test environment for a server: %v", err)
+	}
+	defer gcas.Close()
+	clientDir := glow.GenerateTestDir(name + "_client1")
+	err = SetupTestEnvironment(clientDir, gcaPubkey, gcaPrivKey, []*server.GCAServer{gcas})
+	if err != nil {
+		t.Errorf("unable to set up the client test environment: %v", err)
+	}
+	// create a malformed ct settings file
+	ctPath := path.Join(clientDir, CTSettingsFile)
+	ctf, err := os.Create(ctPath)
+	if err != nil {
+		t.Errorf("could not open ct settings file: %v", err)
+	}
+	ctContent := "-2000\n"
+	_, err = ctf.WriteString(ctContent)
+	if err != nil {
+		ctf.Close()
+		t.Errorf("unable to write ct settings file: %v", err)
+	}
+	// try to start the client
+	client, err := NewClient(clientDir)
+	if err == nil {
+		client.Close()
+		t.Errorf("client read the missing value ct settings file")
+	}
+}

--- a/client/ct_settings_test.go
+++ b/client/ct_settings_test.go
@@ -43,6 +43,7 @@ func TestCISettings(t *testing.T) {
 		ctf.Close()
 		t.Errorf("unable to write ct settings file: %v", err)
 	}
+	ctf.Close()
 	// start the client
 	client, err := NewClient(clientDir)
 	if err != nil {
@@ -106,6 +107,7 @@ func TestCISettingsMalformed(t *testing.T) {
 		ctf.Close()
 		t.Errorf("unable to write ct settings file: %v", err)
 	}
+	ctf.Close()
 	// try to start the client
 	client, err := NewClient(clientDir)
 	if err == nil {
@@ -138,6 +140,7 @@ func TestCISettingsMissingValue(t *testing.T) {
 		ctf.Close()
 		t.Errorf("unable to write ct settings file: %v", err)
 	}
+	ctf.Close()
 	// try to start the client
 	client, err := NewClient(clientDir)
 	if err == nil {

--- a/client/ct_settings_test.go
+++ b/client/ct_settings_test.go
@@ -37,7 +37,7 @@ func TestCISettings(t *testing.T) {
 	if err != nil {
 		t.Errorf("could not open ct settings file: %v", err)
 	}
-	ctContent := "2000\n4000\n" // this will set energy multipler to 2000, divider to 4000
+	ctContent := "-2000\n-4000\n" // this will set energy multipler to 2000, divider to 4000
 	_, err = ctf.WriteString(ctContent)
 	if err != nil {
 		ctf.Close()

--- a/client/ct_settings_test.go
+++ b/client/ct_settings_test.go
@@ -1,0 +1,84 @@
+package client
+
+// The client package is the package that doesn't have any other dependencies,
+// and therefore it's the best place to perform integration tests.
+// reports_test.go also has some pretty comprehensive testing.
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/glowlabs-org/gca-backend/glow"
+	"github.com/glowlabs-org/gca-backend/server"
+)
+
+// CISettingsTest creates an override settings file, and checks that
+// the client sends the correct energy report.
+func TestCISettings(t *testing.T) {
+	name := t.Name()
+	gcas, _, gcaPubkey, gcaPrivKey, err := server.SetupTestEnvironment(name + "_server1")
+	if err != nil {
+		t.Errorf("unable to set up the test environment for a server: %v", err)
+	}
+	defer gcas.Close()
+	clientDir := glow.GenerateTestDir(name + "_client1")
+	err = SetupTestEnvironment(clientDir, gcaPubkey, gcaPrivKey, []*server.GCAServer{gcas})
+	if err != nil {
+		t.Errorf("unable to set up the client test environment: %v", err)
+	}
+	// create a ct settings file
+	ctPath := path.Join(clientDir, CTSettingsFile)
+	ctf, err := os.Create(ctPath)
+	if err != nil {
+		t.Errorf("could not open ct settings file: %v", err)
+	}
+	ctContent := "2000\n4000\n" // this will set energy multipler to 2000, divider to 4000
+	_, err = ctf.WriteString(ctContent)
+	if err != nil {
+		ctf.Close()
+		t.Errorf("unable to write ct settings file: %v", err)
+	}
+	// start the client
+	client, err := NewClient(clientDir)
+	if err != nil {
+		t.Errorf("unable to create client: %v", err)
+	}
+	defer client.Close()
+
+	// Update the monitoring file so that the client submits data to the
+	// server.
+	err = updateMonitorFile(client.staticBaseDir, []uint32{1, 5}, []uint64{500, 3000})
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(2 * sendReportTime)
+
+	// Check that the server got the report.
+	httpPort, _, _ := gcas.Ports()
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%v/api/v1/recent-reports?publicKey=%x", httpPort, client.staticPubKey))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatal("bad status")
+	}
+	var response server.RecentReportsResponse
+	err = json.NewDecoder(resp.Body).Decode(&response)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, report := range response.Reports {
+		if i == 1 && report.PowerOutput != 250 {
+			t.Error("server does not seem to have the report", report.PowerOutput)
+		} else if i == 5 && report.PowerOutput != 1500 {
+			t.Error("server does not seem to have expected report", report.PowerOutput)
+		} else if i != 1 && i != 5 && report.PowerOutput != 0 {
+			t.Error("server has reports we didn't send")
+		}
+	}
+}

--- a/client/ct_settings_test.go
+++ b/client/ct_settings_test.go
@@ -148,3 +148,133 @@ func TestCISettingsMissingValue(t *testing.T) {
 		t.Errorf("client read the missing value ct settings file")
 	}
 }
+
+func TestCISettingsFileNotFound(t *testing.T) {
+	name := t.Name()
+	gcas, _, gcaPubkey, gcaPrivKey, err := server.SetupTestEnvironment(name + "_server1")
+	if err != nil {
+		t.Errorf("unable to set up the test environment for a server: %v", err)
+	}
+	defer gcas.Close()
+	clientDir := glow.GenerateTestDir(name + "_client1")
+	err = SetupTestEnvironment(clientDir, gcaPubkey, gcaPrivKey, []*server.GCAServer{gcas})
+	if err != nil {
+		t.Errorf("unable to set up the client test environment: %v", err)
+	}
+	// Ensure the CT settings file does not exist
+	ctPath := path.Join(clientDir, CTSettingsFile)
+	os.Remove(ctPath)
+
+	// start the client
+	client, err := NewClient(clientDir)
+	if err != nil {
+		t.Errorf("unable to create client: %v", err)
+	}
+	defer client.Close()
+
+	if client.energyMultiplier != EnergyMultiplierDefault || client.energyDivider != EnergyDividerDefault {
+		t.Errorf("default settings not applied: got multiplier %v and divider %v, expected %v and %v",
+			client.energyMultiplier, client.energyDivider, EnergyMultiplierDefault, EnergyDividerDefault)
+	}
+}
+
+func TestCISettingsEmptyFile(t *testing.T) {
+	name := t.Name()
+	gcas, _, gcaPubkey, gcaPrivKey, err := server.SetupTestEnvironment(name + "_server1")
+	if err != nil {
+		t.Errorf("unable to set up the test environment for a server: %v", err)
+	}
+	defer gcas.Close()
+	clientDir := glow.GenerateTestDir(name + "_client1")
+	err = SetupTestEnvironment(clientDir, gcaPubkey, gcaPrivKey, []*server.GCAServer{gcas})
+	if err != nil {
+		t.Errorf("unable to set up the client test environment: %v", err)
+	}
+	// create an empty ct settings file
+	ctPath := path.Join(clientDir, CTSettingsFile)
+	ctf, err := os.Create(ctPath)
+	if err != nil {
+		t.Errorf("could not open ct settings file: %v", err)
+	}
+	ctf.Close()
+
+	// try to start the client
+	client, err := NewClient(clientDir)
+	if err == nil {
+		client.Close()
+		t.Errorf("client read the empty ct settings file")
+	}
+}
+
+func TestCISettingsNonNumericValues(t *testing.T) {
+	name := t.Name()
+	gcas, _, gcaPubkey, gcaPrivKey, err := server.SetupTestEnvironment(name + "_server1")
+	if err != nil {
+		t.Errorf("unable to set up the test environment for a server: %v", err)
+	}
+	defer gcas.Close()
+	clientDir := glow.GenerateTestDir(name + "_client1")
+	err = SetupTestEnvironment(clientDir, gcaPubkey, gcaPrivKey, []*server.GCAServer{gcas})
+	if err != nil {
+		t.Errorf("unable to set up the client test environment: %v", err)
+	}
+	// create a ct settings file with non-numeric values
+	ctPath := path.Join(clientDir, CTSettingsFile)
+	ctf, err := os.Create(ctPath)
+	if err != nil {
+		t.Errorf("could not open ct settings file: %v", err)
+	}
+	ctContent := "not-a-number\nanother-non-number\n"
+	_, err = ctf.WriteString(ctContent)
+	if err != nil {
+		ctf.Close()
+		t.Errorf("unable to write ct settings file: %v", err)
+	}
+	ctf.Close()
+
+	// try to start the client
+	client, err := NewClient(clientDir)
+	if err == nil {
+		client.Close()
+		t.Errorf("client read the non-numeric ct settings file")
+	}
+}
+
+func TestCISettingsLargeValues(t *testing.T) {
+	name := t.Name()
+	gcas, _, gcaPubkey, gcaPrivKey, err := server.SetupTestEnvironment(name + "_server1")
+	if err != nil {
+		t.Errorf("unable to set up the test environment for a server: %v", err)
+	}
+	defer gcas.Close()
+	clientDir := glow.GenerateTestDir(name + "_client1")
+	err = SetupTestEnvironment(clientDir, gcaPubkey, gcaPrivKey, []*server.GCAServer{gcas})
+	if err != nil {
+		t.Errorf("unable to set up the client test environment: %v", err)
+	}
+	// create a ct settings file with large numeric values
+	ctPath := path.Join(clientDir, CTSettingsFile)
+	ctf, err := os.Create(ctPath)
+	if err != nil {
+		t.Errorf("could not open ct settings file: %v", err)
+	}
+	ctContent := "1e10\n1e10\n"
+	_, err = ctf.WriteString(ctContent)
+	if err != nil {
+		ctf.Close()
+		t.Errorf("unable to write ct settings file: %v", err)
+	}
+	ctf.Close()
+
+	// start the client
+	client, err := NewClient(clientDir)
+	if err != nil {
+		t.Errorf("unable to create client: %v", err)
+	}
+	defer client.Close()
+
+	if client.energyMultiplier != 1e10 || client.energyDivider != 1e10 {
+		t.Errorf("unexpected large values: got multiplier %v and divider %v, expected %v and %v",
+			client.energyMultiplier, client.energyDivider, 1e10, 1e10)
+	}
+}

--- a/client/ct_settings_test.go
+++ b/client/ct_settings_test.go
@@ -37,7 +37,7 @@ func TestCISettings(t *testing.T) {
 	if err != nil {
 		t.Errorf("could not open ct settings file: %v", err)
 	}
-	ctContent := "-2000\n-4000\n" // this will set energy multipler to 2000, divider to 4000
+	ctContent := "-2000\n-4000\n" // this will set energy value to 1/2.
 	_, err = ctf.WriteString(ctContent)
 	if err != nil {
 		ctf.Close()
@@ -50,8 +50,7 @@ func TestCISettings(t *testing.T) {
 	}
 	defer client.Close()
 
-	// Update the monitoring file so that the client submits data to the
-	// server.
+	// Update the monitoring file so that the client submits data to the server.
 	err = updateMonitorFile(client.staticBaseDir, []uint32{1, 5}, []uint64{500, 3000})
 	if err != nil {
 		t.Fatal(err)

--- a/client/reports.go
+++ b/client/reports.go
@@ -129,7 +129,7 @@ func (c *Client) staticReadEnergyFile() ([]EnergyRecord, error) {
 			// of performing the underflow conversion, otherwise
 			// the multiplier will be multiplying a giant uint64 by
 			// 4 rather than multiplying a negative number by 4.
-			energy = uint64(EnergyMultiplier * energyF64 / 1e3)
+			energy = uint64(c.energyMultiplier * energyF64 / c.energyDivider)
 		}
 
 		// Append the data to the records slice

--- a/client/reports.go
+++ b/client/reports.go
@@ -364,7 +364,7 @@ func (c *Client) threadedSyncWithServer(latestReading uint32) bool {
 		// 3. Select the first non-banned server.
 		c.mu.Lock()
 		servers := make([]glow.PublicKey, 0, len(c.gcaServers))
-		for server, _ := range c.gcaServers {
+		for server := range c.gcaServers {
 			servers = append(servers, server)
 		}
 		for i := range servers {


### PR DESCRIPTION
If a file `ct-settings.txt` is in the client folder, set the multiplier for the CT energy reading.

Format is
```
multiplier
divider
```

Negative numbers are allowed, the default is -2000 and 1000