### PR TITLE
add two more layers of testing

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -41,7 +41,23 @@ jobs:
           go-version: '1.21.2'
 
       - name: Test
-        run: go test ./... -v -tags test
+        run: go test ./... -v -tags test -count 3
+
+  race:
+    name: Test Race Conditions
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21.2'
+
+      - name: Test
+        run: go test ./... -v -race -tags test
 
   coverage:
     name: Coverage


### PR DESCRIPTION
I did two things here. First, I added another round of testing with the race detector on, that way any easily detected race conditions will result in a failed CI build.

I also set the normal test to run 3 times instead of one, which will make race conditions much more likely to surface. Between the new race test and the existing coverage test, that means the full test suite gets run 5 times across 3 different builds in order to pass.

It should make any NDFs quite visible.