### PR TITLE
Request reset file

### DIFF
--- a/bin/glow-monitor/main.go
+++ b/bin/glow-monitor/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 
 	"github.com/glowlabs-org/gca-backend/client"
@@ -11,7 +12,8 @@ import (
 
 func main() {
 	// Create a new client, using the current directory as the basedir.
-	c, err := client.NewClient("/opt/glow-monitor/")
+	baseDir := "/opt/glow-monitor/"
+	c, err := client.NewClient(baseDir)
 	if err != nil {
 		fmt.Println("unable to create client: ", err)
 		return
@@ -19,8 +21,30 @@ func main() {
 
 	// Wait for a shutdown signal from the OS.
 	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-	<-sigChan
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM, syscall.SIGUSR1, syscall.SIGUSR2)
+
+	done := false
+	for !done {
+		s := <-sigChan
+		switch s {
+		case syscall.SIGINT:
+			done = true
+		case syscall.SIGTERM:
+			done = true
+		case syscall.SIGUSR1:
+			// Dump status to the terminal.
+			fmt.Printf("%v", c.DumpEventLogs())
+		case syscall.SIGUSR2:
+			// Write the status to a file "status.txt" in the client directory. File will be
+			// created and/or truncated before writing.
+			path := filepath.Join(baseDir, "status.txt")
+			fmt.Printf("Dumping server status to %v\n", path)
+			if err := os.WriteFile(path, []byte(c.DumpEventLogs()), 0644); err != nil {
+				fmt.Printf("%v", c.DumpEventLogs())
+				fmt.Printf("\n\n*** Failed to write server status to file %v, dumped to console\n", path)
+			}
+		}
+	}
 
 	// Close the client.
 	err = c.Close()

--- a/client/client.go
+++ b/client/client.go
@@ -87,6 +87,9 @@ type Client struct {
 	// Event log.
 	EventLog *glow.EventLogger
 
+	// Successful sync channel to signal reset loop.
+	syncChan chan bool
+
 	// Sync primitives.
 	mu sync.Mutex
 	tg threadgroup.ThreadGroup
@@ -139,6 +142,10 @@ func NewClient(baseDir string) (*Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error reading CT file: %v", err)
 	}
+
+	// Launch a loop that will monitor for successful syncs, and create a reset file
+	// after 24 hours.
+	c.launchResetFile()
 
 	// Launch the loop that will send UDP reports to the GCA server. The
 	// regular synchronzation checks also happen inside this loop.
@@ -331,4 +338,44 @@ func (c *Client) readCTSettingsFile() error {
 	c.energyMultiplier = mult
 	c.energyDivider = div
 	return nil
+}
+
+func (c *Client) launchResetFile() {
+	c.syncChan = make(chan bool)
+	path := filepath.Join(c.staticBaseDir, RequestResetFile)
+	c.tg.AfterStop(func() error {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("can't remove request reset file %v: %v", path, err)
+		}
+		return nil
+	})
+	c.tg.Launch(func() {
+		timer := time.NewTimer(RequestResetDelay)
+		for {
+			select {
+			case <-c.tg.StopChan():
+				return
+			case <-c.syncChan:
+				if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+					panic("can't remove request reset file: " + path)
+				}
+				timer.Stop()
+				// Consume any timer still in the channel.
+				select {
+				case <-timer.C:
+				default:
+				}
+				timer.Reset(RequestResetDelay)
+			case <-timer.C:
+				c.EventLog.Printf("creating reset file: %v", path)
+				f, err := os.Create(path)
+				if err != nil {
+					panic("can't create request reset file: " + path)
+				}
+				if err := f.Close(); err != nil {
+					panic("can't close request reset file: " + path)
+				}
+			}
+		}
+	})
 }

--- a/client/consts.go
+++ b/client/consts.go
@@ -25,4 +25,7 @@ const (
 
 	// CTSettingsFile contains the current transformer multiplier.
 	CTSettingsFile = "ct-settings.txt"
+
+	// RequestResetFile is a file that asks the system for a reset.
+	RequestResetFile = "request-reset.txt"
 )

--- a/client/consts_p.go
+++ b/client/consts_p.go
@@ -37,6 +37,12 @@ const (
 	// operation is all but guaranteed to get them dropped.
 	UDPSleepSyncTime = time.Second
 
+	// Event log constants. These values limit the in-memory footprint
+	// of the event logging system.
+	EventLogExpiry         = 7 * 24 * time.Hour
+	EventLogLimitBytes     = 1e7
+	EventLogLineLimitBytes = 200
+
 	// RequestResetDelay is the delay between successful sync calls after which
 	// a request restart file will be created.
 	RequestResetDelay = 24 * time.Hour

--- a/client/consts_p.go
+++ b/client/consts_p.go
@@ -37,6 +37,10 @@ const (
 	// operation is all but guaranteed to get them dropped.
 	UDPSleepSyncTime = time.Second
 
+	// RequestResetDelay is the delay between successful sync calls after which
+	// a request restart file will be created.
+	RequestResetDelay = 24 * time.Hour
+
 	// Indicate that this is not a testing build of the client.
 	testMode = false
 )

--- a/client/consts_t.go
+++ b/client/consts_t.go
@@ -33,6 +33,10 @@ const (
 	// operation is all but guaranteed to get them dropped.
 	UDPSleepSyncTime = time.Millisecond
 
+	// RequestResetDelay is the delay between successful sync calls after which
+	// a request restart file will be created.
+	RequestResetDelay = 200 * time.Millisecond
+
 	// Indicate that this is a testing build of the client.
 	testMode = true
 )

--- a/client/consts_t.go
+++ b/client/consts_t.go
@@ -33,6 +33,12 @@ const (
 	// operation is all but guaranteed to get them dropped.
 	UDPSleepSyncTime = time.Millisecond
 
+	// Event log constants. These values limit the in-memory footprint
+	// of the event logging system.
+	EventLogExpiry         = 20 * time.Second // enough time for the tests to complete
+	EventLogLimitBytes     = 1000
+	EventLogLineLimitBytes = 200
+
 	// RequestResetDelay is the delay between successful sync calls after which
 	// a request restart file will be created.
 	RequestResetDelay = 200 * time.Millisecond

--- a/client/consts_t.go
+++ b/client/consts_t.go
@@ -41,7 +41,7 @@ const (
 
 	// RequestResetDelay is the delay between successful sync calls after which
 	// a request restart file will be created.
-	RequestResetDelay = 200 * time.Millisecond
+	RequestResetDelay = 100 * time.Millisecond
 
 	// Indicate that this is a testing build of the client.
 	testMode = true

--- a/client/event_log_integration_test.go
+++ b/client/event_log_integration_test.go
@@ -1,0 +1,65 @@
+package client
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/glowlabs-org/gca-backend/glow"
+)
+
+func TestEventLogIntegration(t *testing.T) {
+	client, gcas, _, err := FullClientTestEnvironment(t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	defer glow.SetCurrentTimeslot(0)
+
+	l1 := "read energy file"
+	l2 := "udp report sent"
+	l3 := "negative energy value read"
+	l4 := "invalid energy value in energy file: random error here"
+
+	// Send a report to the server
+	err = updateMonitorFile(client.staticBaseDir, []uint32{1, 5, 10}, []uint64{500, 3000, 5000})
+	if err != nil {
+		gcas.Close()
+		t.Fatal(err)
+	}
+	time.Sleep(2 * sendReportTime)
+	dump := client.DumpEventLogs()
+	if !strings.Contains(dump, l1) {
+		t.Errorf("logs missing: %v", l1)
+	}
+	if !strings.Contains(dump, l2) {
+		t.Errorf("logs missing: %v", l1)
+	}
+	if !strings.Contains(dump, l3) {
+		t.Errorf("logs missing: %v", l1)
+	}
+	if strings.Contains(dump, l4) {
+		t.Errorf("logs contain unexpected: %v", l1)
+	}
+
+	// Add a report using the magic number that creates a bad record.
+	err = updateMonitorFile(client.staticBaseDir, []uint32{20}, []uint64{34404})
+	if err != nil {
+		gcas.Close()
+		t.Fatal(err)
+	}
+	time.Sleep(2 * sendReportTime)
+	dump = client.DumpEventLogs()
+	if !strings.Contains(dump, l1) {
+		t.Errorf("logs missing: %v", l1)
+	}
+	if !strings.Contains(dump, l2) {
+		t.Errorf("logs missing: %v", l1)
+	}
+	if !strings.Contains(dump, l3) {
+		t.Errorf("logs missing: %v", l1)
+	}
+	if !strings.Contains(dump, l4) {
+		t.Errorf("logs missing: %v", l1)
+	}
+}

--- a/client/reports.go
+++ b/client/reports.go
@@ -548,6 +548,9 @@ func (c *Client) threadedSyncWithServer(latestReading uint32) bool {
 		}
 	}
 
+	// Let the reset handler know that we had a successful sync.
+	c.syncChan <- true
+
 	return true
 }
 

--- a/client/reset_file_test.go
+++ b/client/reset_file_test.go
@@ -1,0 +1,72 @@
+package client
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestResetFileCreateAndRemove(t *testing.T) {
+	// Create a client and a server to perform the test.
+	client, gcas, _, _ := FullClientTestEnvironment(t.Name())
+	defer client.Close()
+	defer gcas.Close()
+
+	path := filepath.Join(client.staticBaseDir, RequestResetFile)
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("exists when it should not: %v", path)
+	}
+
+	// Execute a sync with the server and make sure the file is still there.
+	if s := client.threadedSyncWithServer(0); !s {
+		t.Error("sync failed")
+	}
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("exists when it should not: %v", path)
+	}
+
+	// Wait for the thread to create the file
+	time.Sleep(RequestResetDelay + 10*time.Millisecond)
+
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		t.Errorf("does not exist when it should: %v", path)
+	}
+
+	// Send another sync
+	if s := client.threadedSyncWithServer(0); !s {
+		t.Error("sync failed")
+	}
+
+	// Give the thread time to remove the file
+	time.Sleep(20 * time.Millisecond)
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("exists when it should not: %v", path)
+	}
+}
+
+func TestResetRemoveOnClose(t *testing.T) {
+	// Create a client and a server to perform the test.
+	client, gcas, _, _ := FullClientTestEnvironment(t.Name())
+	defer gcas.Close()
+
+	path := filepath.Join(client.staticBaseDir, RequestResetFile)
+
+	// Wait for the client to create a file
+	time.Sleep(RequestResetDelay + 10*time.Millisecond)
+
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		client.Close()
+		t.Errorf("does not exist when it should: %v", path)
+	}
+
+	// Stop the client
+	client.Close()
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("exists when it should not: %v", path)
+	}
+}

--- a/glow/event_log.go
+++ b/glow/event_log.go
@@ -1,0 +1,168 @@
+package glow
+
+// This file contains a simple event logger, designed to collect a limited
+// number of timestamped logs and output them to file or terminal.
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+)
+
+// LogEntry contains a logged string, and a list of time ordered timestamps.
+type LogEntry struct {
+	line    string      // The logged line
+	updates []time.Time // Time ordered list of updates (time.Time)
+}
+
+// EventLogger keeps track logged events and manages their size in memory,
+// allowing for duplicate entries.
+type EventLogger struct {
+	logs            map[string]*LogEntry // Map of log lines to entries
+	logExpiry       time.Duration        // Duration to retain logs
+	logMaxBytes     int                  // Total allowed size for logged strings
+	logMaxLineBytes int                  // Maximum logged string size per line
+	logSizeBytes    int                  // Current size of logged strings
+	mu              sync.Mutex
+}
+
+// NewEventLogger creates an in-memory event logger with size limitations to protect the client
+// from run-time failures.
+func NewEventLogger(logExpiry time.Duration, logMaxBytes, logMaxLineBytes int) *EventLogger {
+	// Require parameters that allow logs to be collected, and enforce some reasonable limits.
+	if logExpiry == time.Duration(0) || logMaxBytes <= 0 || logMaxLineBytes <= 0 {
+		fmt.Println("LogEntry log settings do not allow log collection.")
+		return nil
+	}
+	if logMaxBytes >= 1e8 || logMaxLineBytes >= 1e3 {
+		fmt.Printf("LogEntry log parameters are too high: max bytes is %v and max line bytes is %v", logMaxBytes, logMaxLineBytes)
+		return nil
+	}
+	return &EventLogger{
+		logs:            make(map[string]*LogEntry),
+		logExpiry:       logExpiry,
+		logMaxBytes:     logMaxBytes,
+		logMaxLineBytes: logMaxLineBytes,
+	}
+}
+
+// ExpireLogs expires all logs, removing them after they have no unexpired timestamps.
+func (l *EventLogger) ExpireLogs(now time.Time) {
+	expireTime := now.Add(-l.logExpiry)
+	keysToDelete := []string{}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	// Log entries past the expiry time are removed and not retained in any way.
+	for _, entry := range l.logs {
+		removeIdx := 0
+		for _, ts := range entry.updates {
+			if ts.Before(expireTime) {
+				removeIdx++
+			} else {
+				break
+			}
+		}
+		entry.updates = entry.updates[removeIdx:]
+		if len(entry.updates) == 0 {
+			keysToDelete = append(keysToDelete, entry.line)
+		}
+	}
+	// Remove all unused log entries
+	for _, key := range keysToDelete {
+		delete(l.logs, key)
+	}
+}
+
+// Add a timestamped event to the log, truncating and removing logs
+// according to the EventLogger rules.
+func (l *EventLogger) Printf(format string, a ...interface{}) {
+	now := time.Now()
+	l.ExpireLogs(now)
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	// Apply line truncation.
+	key := fmt.Sprintf(format, a...)
+	if len(key) > l.logMaxLineBytes {
+		key = key[:l.logMaxLineBytes]
+
+	}
+	sizeRequired := 2 * len(key) // The size used is twice the string length
+	if sizeRequired > l.logMaxBytes {
+		return // We can't ever store this.
+	}
+
+	// Avoid log duplication.
+	entry, found := l.logs[key]
+	if found {
+		entry.updates = append(entry.updates, now)
+		return
+	}
+
+	// Remove the oldest logs first.
+	var updateOrder []*LogEntry
+
+	if sizeRequired+l.logSizeBytes > l.logMaxBytes {
+		updateOrder = make([]*LogEntry, 0)
+		for _, entry := range l.logs {
+			updateOrder = append(updateOrder, entry)
+		}
+		sort.Slice(updateOrder, func(i, j int) bool {
+			return updateOrder[i].updates[len(updateOrder[i].updates)-1].Before(updateOrder[j].updates[len(updateOrder[j].updates)-1]) // Ascending sort
+		})
+	}
+
+	// While there is not enough space, remove logs oldest to newest.
+	for sizeRequired+l.logSizeBytes > l.logMaxBytes {
+		oldest := updateOrder[0]
+		updateOrder = updateOrder[1:]
+		l.logSizeBytes -= 2 * len(oldest.line)
+		delete(l.logs, oldest.line)
+	}
+
+	// Add the entry
+	l.logSizeBytes += sizeRequired
+	nxt := &LogEntry{
+		line:    key,
+		updates: make([]time.Time, 0),
+	}
+	nxt.updates = append(nxt.updates, now)
+	l.logs[key] = nxt
+}
+
+// DumpLogEntries expires the logs and returns a map of logs to timestamps, and a time
+// ordered slice of logs.
+func (l *EventLogger) DumpLogEntries() (map[string][]time.Time, []string) {
+	l.ExpireLogs(time.Now())
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	retMap := make(map[string][]time.Time, 0)
+	retSlice := make([]string, 0)
+	type orderMap struct {
+		line   string
+		latest time.Time
+	}
+	updateOrder := []*orderMap{}
+	for _, entry := range l.logs {
+		// Create the timestamps map entry
+		timestamps := make([]time.Time, 0)
+		timestamps = append(timestamps, entry.updates...)
+		retMap[entry.line] = timestamps
+
+		// Add the last timestamp to the update order
+		nxt := &orderMap{
+			line:   entry.line,
+			latest: entry.updates[len(entry.updates)-1],
+		}
+		updateOrder = append(updateOrder, nxt)
+	}
+	sort.Slice(updateOrder, func(i, j int) bool {
+		return updateOrder[i].latest.Before(updateOrder[j].latest) // Ascending sort
+	})
+	for _, entry := range updateOrder {
+		retSlice = append(retSlice, entry.line)
+	}
+	return retMap, retSlice
+}

--- a/glow/event_log_test.go
+++ b/glow/event_log_test.go
@@ -1,0 +1,113 @@
+package glow
+
+import (
+	"testing"
+	"time"
+)
+
+func TestInitialConditionHandling(t *testing.T) {
+	l := NewEventLogger(0, -1, -1)
+	if l != nil {
+		t.Errorf("Expected nil logger due to invalid initial conditions, got non-nil")
+	}
+}
+
+func TestEventLogBasic(t *testing.T) {
+	l := NewEventLogger(time.Second, 1000, 100) // 2 logs of size 5 requires 20 bytes
+	l.Printf("abcde")
+	time.Sleep(5 * time.Millisecond)
+	l.Printf("fghij")
+	time.Sleep(5 * time.Millisecond)
+	entries, order := l.DumpLogEntries()
+	if len(entries) != 2 {
+		t.Errorf("wrong size, expecting %v got %v", 2, len(entries))
+	}
+	if _, found := entries["abcde"]; !found {
+		t.Errorf("missing log: %v", "abcde")
+	}
+	if _, found := entries["fghij"]; !found {
+		t.Errorf("missing log: %v", "fghij")
+	}
+	if len(order) != 2 {
+		t.Errorf("wrong size, expecting %v got %v", 2, len(order))
+	}
+	if order[0] != "abcde" {
+		t.Errorf("out of order: %v", "abcde")
+	}
+	if order[1] != "fghij" {
+		t.Errorf("out of order: %v", "fghij")
+	}
+}
+
+func TestEventLogMaxSize(t *testing.T) {
+	l := NewEventLogger(time.Second, 20, 100) // 2 logs of size 5 requires 20 bytes
+	l.Printf("abcde")
+	time.Sleep(5 * time.Millisecond)
+	l.Printf("fghij")
+	time.Sleep(5 * time.Millisecond)
+	entries, _ := l.DumpLogEntries()
+	if len(entries) != 2 {
+		t.Fatalf("Expected 2, got %v", len(entries))
+	}
+	if _, found := entries["abcde"]; !found {
+		t.Errorf("missing log: %v", "abcde")
+	}
+	if _, found := entries["fghij"]; !found {
+		t.Errorf("missing log: %v", "fghij")
+	}
+	l.Printf("klmno")
+	time.Sleep(5 * time.Millisecond)
+	l.Printf("pqrst")
+	time.Sleep(5 * time.Millisecond)
+	entries, _ = l.DumpLogEntries()
+	if len(entries) != 2 {
+		t.Fatalf("Expected 2, got %v", len(entries))
+	}
+	if _, found := entries["klmno"]; !found {
+		t.Errorf("missing log: %v", "klmno")
+	}
+	if _, found := entries["pqrst"]; !found {
+		t.Errorf("missing log: %v", "pqrst")
+	}
+}
+
+func TestEventLogExpiry(t *testing.T) {
+	l := NewEventLogger(5*time.Millisecond, 1000, 100)
+	l.Printf("abcde")
+	l.Printf("fghij")
+	entries, _ := l.DumpLogEntries()
+	if len(entries) != 2 {
+		t.Fatalf("Expected 2, got %v", len(entries))
+	}
+	if _, found := entries["abcde"]; !found {
+		t.Errorf("missing log: %v", "abcde")
+	}
+	if _, found := entries["fghij"]; !found {
+		t.Errorf("missing log: %v", "fghij")
+	}
+	time.Sleep(5 * time.Millisecond)
+	l.Printf("klmno")
+	l.Printf("pqrst")
+	entries, _ = l.DumpLogEntries()
+	if len(entries) != 2 {
+		t.Fatalf("Expected 2, got %v", len(entries))
+	}
+	if _, found := entries["klmno"]; !found {
+		t.Errorf("missing log: %v", "klmno")
+	}
+	if _, found := entries["pqrst"]; !found {
+		t.Errorf("missing log: %v", "pqrst")
+	}
+}
+
+func TestEventLogLineLengthLimit(t *testing.T) {
+	l := NewEventLogger(5*time.Millisecond, 1000, 5)
+	l.Printf("abcdefghij")
+	entries, _ := l.DumpLogEntries()
+	if _, found := entries["abcdefghij"]; found {
+		t.Errorf("log was not truncated: %v", "abcdefghij")
+	}
+	if _, found := entries["abcde"]; !found {
+		t.Errorf("missing log: %v", "abcde")
+	}
+}


### PR DESCRIPTION
Create a file called "request-reset.txt" when the client does not have a successful sync for 24 hours. This is intended to work with a systemd server that restarts the monitor.

Rules:

- Client does *not* remove the file on startup
- Client removes the file on close
- A timer is set for 24 hours, after which a file is created
- On a successful sync, the timer is reset to 24 hours
