### PR TITLE
release script

### DIFF
--- a/bin/glow-monitor/.gitignore
+++ b/bin/glow-monitor/.gitignore
@@ -1,2 +1,4 @@
 glow-monitor
 halki-password
+stage
+v2-upgrade.zip

--- a/bin/glow-monitor/release.sh
+++ b/bin/glow-monitor/release.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+STAGE_DIR="stage"
+CLIENTS_DIR="stage/.config/gca-data/clients"
+ZIP_FILE="v2-upgrade.zip"
+
+OTHER_FILES_DIR="additional_files" # Directory containing other files to include in the release
+
+rm -rf ${STAGE_DIR}
+mkdir -p ${CLIENTS_DIR}
+
+echo "Building glow_monitor"
+GOOS=linux GOARCH=arm GOARM=7 go build -o ${CLIENTS_DIR}/glow_monitor main.go
+
+echo "Copying clients files"
+cp halki-app monitor-sync.* monitor-udp.* ${CLIENTS_DIR}/
+if [[ -f halki-password ]]; then
+cp halki-password ${CLIENTS_DIR}/
+fi
+
+echo "Copying installation scripts"
+cp ../gca-admin/equipment-prescan.sh ../gca-admin/equipment-setup.sh ../gca-admin/server-setup.sh ${STAGE_DIR}
+
+echo "Creating zip file"
+cd ${STAGE_DIR}
+zip -r ../${ZIP_FILE} * .*
+cd ..
+echo "Release created at ${ZIP_FILE}"

--- a/bin/glow-monitor/release.sh
+++ b/bin/glow-monitor/release.sh
@@ -7,8 +7,6 @@ STAGE_DIR="stage"
 CLIENTS_DIR="stage/.config/gca-data/clients"
 ZIP_FILE="v2-upgrade.zip"
 
-OTHER_FILES_DIR="additional_files" # Directory containing other files to include in the release
-
 rm -rf ${STAGE_DIR}
 mkdir -p ${CLIENTS_DIR}
 
@@ -25,6 +23,7 @@ echo "Copying installation scripts"
 cp ../gca-admin/equipment-prescan.sh ../gca-admin/equipment-setup.sh ../gca-admin/server-setup.sh ${STAGE_DIR}
 
 echo "Creating zip file"
+rm ${ZIP_FILE}
 cd ${STAGE_DIR}
 zip -r ../${ZIP_FILE} * .*
 cd ..


### PR DESCRIPTION
Release script for monitor software upgrade

Add a file `halki-password` if required
Run `release.sh` from `bin/glow-monitor` directory
Creates a v2-upgrade.zip that should be unzipped in the `/home/user` directory on the GCA lockbook